### PR TITLE
test: Update jest.config.js to resolve warnings

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,17 +1,13 @@
-require('ts-node/register');
-
 module.exports = {
-  'moduleFileExtensions': [
+  moduleFileExtensions: [
     'js',
     'json',
     'ts',
   ],
-  'rootDir': 'lib',
-  'testRegex': '/lib/.*\\.spec\\.(ts|js)$',
-  'globals': {
-    'ts-jest': {
-      'tsConfig': 'tsconfig.json'
-    }
+  rootDir: 'lib',
+  testRegex: '/lib/.*\\.spec\\.(ts|js)$',
+  transform: {
+    '^.+\\.ts$': 'ts-jest',
   },
-  'preset': 'ts-jest',
+  preset: 'ts-jest',
 };


### PR DESCRIPTION
Running `(p)npm test` logs these warnings:

```
ts-jest[ts-jest-transformer] (WARN) Define `ts-jest` config under `globals` is deprecated. Please do
transform: {
    <transform_regex>: ['ts-jest', { /* ts-jest config goes here in Jest */ }],
},
ts-jest[backports] (WARN) "[jest-config].globals.ts-jest.tsConfig" is deprecated, use "[jest-config].globals.ts-jest.tsconfig" instead.
ts-jest[backports] (WARN) Your Jest configuration is outdated. Use the CLI to help migrating it: ts-jest config:migrate <config-file>.
```

This PR makes the recommended changes and resolves the warnings.